### PR TITLE
Display version of what is specified in ~/.zpreztorc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ Powerline for [Prezto](http://github.com/sorin-ionescu/prezto) ZSH
 * Single line prompt
 * Git branch info (current branch and modified states)
 * Time since last commit
-* RVM current ruby version / gemset
+* Current version of what is specified in ~/.zpreztorc
+```
+zstyle ':prezto:module:prompt:powerline:versioninfo:' command 'nvm version'
+```
 
 ![Example](https://raw.github.com/davidjrice/prezto_powerline/master/prompt.png)
 
@@ -57,4 +60,3 @@ This prompt is inspired by:
 * Moar configurable
 * Extract functions to Prezto modules?
 * Use better Prezto best practices...?
-* Handle NVM version info?

--- a/prompt_powerline_setup
+++ b/prompt_powerline_setup
@@ -60,17 +60,6 @@ time_since_commit()() {
   fi
 }
 
-rvm_info_for_prompt() {
-  if [[ -d ~/.rvm/ ]]; then
-    local ruby_version=$(~/.rvm/bin/rvm-prompt)
-    if [ -n "$ruby_version" ]; then
-      echo "$ruby_version"
-    fi
-  else
-    echo ""
-  fi
-}
-
 prompt_powerline_precmd() {
   # Check for untracked files or updated submodules since vcs_info doesn't.
   if [[ ! -z $(git ls-files --other --exclude-standard 2> /dev/null) ]]; then
@@ -81,9 +70,6 @@ prompt_powerline_precmd() {
   zstyle ':vcs_info:*:prompt:*' formats "${fmt_branch}"
 
   vcs_info 'prompt'
-  RVM_PRECMD_INFO=$(rvm_info_for_prompt)
-
-  # zstyle ':prezto:module:ruby' rvm '%r'
 }
 
 prompt_powerline_setup() {
@@ -144,28 +130,6 @@ prompt_powerline_setup() {
   zstyle ':vcs_info:*:prompt:*' formats       "${fmt_branch}"
   zstyle ':vcs_info:*:prompt:*' nvcsformats   ""
 
-  # SPLIT RVM PROMPT INFO
-  # TODO: should assign this to local variable? somehow doesn't work correctly.
-  rvm_split=("${(s/@/)$(rvm_info_for_prompt)}")
-
-  # if [ "$POWERLINE_RIGHT_B" = "" ]; then
-    # POWERLINE_RIGHT_B=%D{%H:%M:%S}
-    local powerline_right_b=$rvm_split[1]
-  # fi
-
-  # if [ "$POWERLINE_RIGHT_A" = "" ]; then
-    local powerline_right_a=$rvm_split[2]
-  # fi
-
-  # Setup powerline style colouring
-  POWERLINE_COLOR_BG_GRAY=%K{240}
-  POWERLINE_COLOR_BG_LIGHT_GRAY=%K{240}
-  POWERLINE_COLOR_BG_WHITE=%K{255}
-
-  POWERLINE_COLOR_FG_GRAY=%F{240}
-  POWERLINE_COLOR_FG_LIGHT_GRAY=%F{240}
-  POWERLINE_COLOR_FG_WHITE=%F{255}
-
   POWERLINE_SEPARATOR=$'\uE0B0'
   POWERLINE_R_SEPARATOR=$'\uE0B2'
 
@@ -174,9 +138,11 @@ prompt_powerline_setup() {
   POWERLINE_LEFT_C=" %k%f%F{white}%K{black}"'$(git_time_details)'" %k%f%F{black}"$POWERLINE_SEPARATOR"%f "
 
   PROMPT=$POWERLINE_LEFT_A$POWERLINE_LEFT_B$POWERLINE_LEFT_C
-  # RPROMPT=$POWERLINE_COLOR_FG_WHITE$POWERLINE_R_SEPARATOR"%f$POWERLINE_COLOR_BG_WHITE $POWERLINE_COLOR_FG_GRAY$powerline_right_b "$POWERLINE_R_SEPARATOR"%f%k$POWERLINE_COLOR_BG_GRAY$POWERLINE_COLOR_FG_WHITE $powerline_right_a %f%k"
-  # RPROMPT=$POWERLINE_COLOR_FG_WHITE$POWERLINE_R_SEPARATOR"%f$POWERLINE_COLOR_BG_WHITE $POWERLINE_COLOR_FG_GRAY"'$powerline_right_b'" "$POWERLINE_R_SEPARATOR"%f%k$POWERLINE_COLOR_BG_GRAY$POWERLINE_COLOR_FG_WHITE "'$powerline_right_a'" %f%k"
-  RPROMPT=$POWERLINE_COLOR_FG_WHITE$POWERLINE_R_SEPARATOR"%f$POWERLINE_COLOR_BG_WHITE $POWERLINE_COLOR_FG_GRAY"'$(rvm_info_for_prompt)'" "
+
+  zstyle -s ':prezto:module:prompt:powerline:versioninfo:' command 'command'
+  if [ -n "$command" ]; then
+    RPROMPT="%F{white}$POWERLINE_R_SEPARATOR%f%F{black}%K{white} \$($command) %f%k"
+  fi
 }
 
 prompt_powerline_setup "$@"


### PR DESCRIPTION
Display output of a command specified in ~/.zpreztorc. For example, the following line displays node version at rprompt.
```
zstyle ':prezto:module:prompt:powerline:versioninfo:' command 'nvm version'
```
If this property is empty, anything isn't shown at rprompt.

If this commit is merged,
Close #14 
Close #5 
Close #10 