### PR TITLE
Prevent hiding of partial lines of output or previous command by the prompt

### DIFF
--- a/prompt_powerline_setup
+++ b/prompt_powerline_setup
@@ -89,7 +89,7 @@ prompt_powerline_precmd() {
 prompt_powerline_setup() {
   setopt LOCAL_OPTIONS
   unsetopt XTRACE KSH_ARRAYS
-  prompt_opts=(cr percent subst)
+  prompt_opts=(cr percent sp subst)
 
   autoload -Uz add-zsh-hook
   autoload -Uz vcs_info


### PR DESCRIPTION
When the output of the previous command does not end with a newline, the prompt hides that output. You can however see it for a fraction of a second. This PR fixes that behavior. By default a ‘%’ is appended to the partial line output for a normal user (and a ‘#’ for root). This can be customized by setting the value of the env variable `PROMPT_EOL_MARK` 
